### PR TITLE
feat: add configuration form for URL parameters

### DIFF
--- a/js/config-form.js
+++ b/js/config-form.js
@@ -1,0 +1,137 @@
+const form = document.getElementById('config-form');
+const portfolioFields = document.getElementById('portfolio-fields');
+const btnAddPortfolio = document.getElementById('btn-add-portfolio');
+const progressContainer = document.querySelector('.progress-container');
+const countdownContainer = document.getElementById('countdown-container');
+
+/**
+ * Creates a portfolio ID input row.
+ * @param {string} value - Initial value for the input
+ * @param {boolean} removable - Whether the row should have a remove button
+ * @returns {HTMLElement} The portfolio row element
+ */
+function createPortfolioRow(value = '', removable = false) {
+    const row = document.createElement('div');
+    row.className = 'portfolio-row';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Portfolio ID';
+    input.value = value;
+    input.className = 'portfolio-input';
+    row.appendChild(input);
+
+    if (removable) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn-remove';
+        btn.textContent = 'Remove';
+        btn.addEventListener('click', () => row.remove());
+        row.appendChild(btn);
+    }
+
+    return row;
+}
+
+/**
+ * Populates the form fields from current URL parameters.
+ */
+function populateFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+
+    // Clear existing portfolio rows
+    portfolioFields.innerHTML = '';
+
+    // Portfolio IDs
+    const portfolioIdParam = params.get('portfolioId');
+    const ids = portfolioIdParam ? portfolioIdParam.split(',').filter(Boolean) : [];
+
+    if (ids.length === 0) {
+        // Always show at least one field
+        portfolioFields.appendChild(createPortfolioRow('', false));
+    } else {
+        ids.forEach((id, index) => {
+            portfolioFields.appendChild(createPortfolioRow(id, index > 0));
+        });
+    }
+
+    // Other fields
+    const targetValue = params.get('targetValue');
+    if (targetValue) {
+        document.getElementById('input-target-value').value = targetValue;
+    }
+
+    const yearlyReturn = params.get('assumedYearlyReturn');
+    if (yearlyReturn) {
+        document.getElementById('input-yearly-return').value = yearlyReturn;
+    }
+
+    const monthlyContribution = params.get('monthlyContribution');
+    if (monthlyContribution) {
+        document.getElementById('input-monthly-contribution').value = monthlyContribution;
+    }
+}
+
+/**
+ * Shows the configuration form, hiding the progress display.
+ */
+export function showForm() {
+    populateFromUrl();
+    progressContainer.style.display = 'none';
+    countdownContainer.style.display = 'none';
+    form.style.display = 'block';
+
+    // Focus the first input
+    const firstInput = form.querySelector('input');
+    if (firstInput) firstInput.focus();
+}
+
+/**
+ * Initializes the configuration form event handlers.
+ */
+export function initConfigForm() {
+    // Add portfolio button
+    btnAddPortfolio.addEventListener('click', () => {
+        portfolioFields.appendChild(createPortfolioRow('', true));
+        const inputs = portfolioFields.querySelectorAll('input');
+        inputs[inputs.length - 1].focus();
+    });
+
+    // Form submission
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+
+        const params = new URLSearchParams();
+
+        // Collect portfolio IDs
+        const inputs = portfolioFields.querySelectorAll('.portfolio-input');
+        const ids = Array.from(inputs)
+            .map(input => input.value.trim())
+            .filter(Boolean);
+
+        if (ids.length > 0) {
+            params.set('portfolioId', ids.join(','));
+        }
+
+        // Target value
+        const targetValue = document.getElementById('input-target-value').value.trim();
+        if (targetValue) {
+            params.set('targetValue', targetValue);
+        }
+
+        // Assumed yearly return — convert comma to dot
+        const yearlyReturn = document.getElementById('input-yearly-return').value.trim().replace(',', '.');
+        if (yearlyReturn) {
+            params.set('assumedYearlyReturn', yearlyReturn);
+        }
+
+        // Monthly contribution
+        const monthlyContribution = document.getElementById('input-monthly-contribution').value.trim();
+        if (monthlyContribution) {
+            params.set('monthlyContribution', monthlyContribution);
+        }
+
+        // Navigate to the new URL with parameters, which triggers a full reload
+        window.location.search = params.toString();
+    });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,19 @@
 import { setConfig, updateProgress } from './progress.js';
+import { initConfigForm, showForm } from './config-form.js';
 
 /**
  * Initialize application by parsing URL parameters and starting the progress update
  */
 function initApp() {
-    // Parse URL parameters
+    initConfigForm();
+
     const urlParams = new URLSearchParams(window.location.search);
+
+    // If no query parameters are present, show the configuration form
+    if (urlParams.toString() === '') {
+        showForm();
+        return;
+    }
 
     // Parse portfolio IDs
     const portfolioIdParam = urlParams.get('portfolioId');
@@ -41,6 +49,15 @@ function initApp() {
 
     // Update hourly
     setInterval(updateProgress, 3600000);
+
+    // Press 'C' to open configuration form
+    document.addEventListener('keydown', (e) => {
+        // Don't trigger when typing in an input or form is already visible
+        if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+        if (e.key === 'c' || e.key === 'C') {
+            showForm();
+        }
+    });
 }
 
 // Initialize the application when the DOM is fully loaded

--- a/progress.html
+++ b/progress.html
@@ -6,6 +6,7 @@
     body {
         background-color: rgba(55, 65, 81, 1) !important;
         font-family: Arial, sans-serif;
+        margin: 0;
     }
 
     .container {
@@ -45,6 +46,112 @@
     #countdown {
         font-size: 1.2rem;
     }
+
+    /* Configuration form */
+    #config-form {
+        display: none;
+        color: white;
+        width: 400px;
+        max-width: 90vw;
+    }
+
+    #config-form .form-group {
+        margin-bottom: 1.2rem;
+    }
+
+    #config-form label {
+        display: block;
+        margin-bottom: 0.4rem;
+        font-size: 0.9rem;
+        color: rgba(209, 213, 219, 1);
+    }
+
+    #config-form input[type="text"],
+    #config-form input[type="number"] {
+        width: 100%;
+        padding: 0.5rem 0.6rem;
+        border: 1px solid rgba(107, 114, 128, 1);
+        border-radius: 4px;
+        background: rgba(31, 41, 55, 1);
+        color: white;
+        font-size: 0.95rem;
+        box-sizing: border-box;
+    }
+
+    #config-form input:focus {
+        outline: none;
+        border-color: rgba(99, 102, 241, 1);
+    }
+
+    #config-form .suffix {
+        color: rgba(156, 163, 175, 1);
+        font-size: 0.85rem;
+        margin-left: 0.4rem;
+    }
+
+    #config-form .input-with-suffix {
+        display: flex;
+        align-items: center;
+    }
+
+    #config-form .input-with-suffix input {
+        flex: 1;
+    }
+
+    #portfolio-fields .portfolio-row {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0.4rem;
+        gap: 0.4rem;
+    }
+
+    #portfolio-fields .portfolio-row input {
+        flex: 1;
+    }
+
+    #config-form button {
+        padding: 0.4rem 0.8rem;
+        border: 1px solid rgba(107, 114, 128, 1);
+        border-radius: 4px;
+        background: rgba(55, 65, 81, 1);
+        color: white;
+        cursor: pointer;
+        font-size: 0.85rem;
+    }
+
+    #config-form button:hover {
+        background: rgba(75, 85, 99, 1);
+    }
+
+    #config-form .btn-remove {
+        padding: 0.4rem 0.6rem;
+        background: rgba(127, 29, 29, 0.6);
+        border-color: rgba(153, 27, 27, 0.8);
+        font-size: 0.8rem;
+        line-height: 1;
+    }
+
+    #config-form .btn-remove:hover {
+        background: rgba(153, 27, 27, 0.8);
+    }
+
+    #config-form .btn-add {
+        margin-top: 0.2rem;
+        font-size: 0.85rem;
+    }
+
+    #config-form .btn-save {
+        margin-top: 0.8rem;
+        padding: 0.6rem 1.6rem;
+        background: rgba(79, 70, 229, 1);
+        border-color: rgba(99, 102, 241, 1);
+        font-size: 1rem;
+        width: 100%;
+    }
+
+    #config-form .btn-save:hover {
+        background: rgba(99, 102, 241, 1);
+    }
 </style>
 
 <body>
@@ -55,6 +162,40 @@
         <div id="countdown-container" style="display: none;">
             <p id="countdown"></p>
         </div>
+
+        <form id="config-form">
+            <div class="form-group">
+                <label>Portfolio IDs</label>
+                <div id="portfolio-fields"></div>
+                <button type="button" id="btn-add-portfolio" class="btn-add">+ Add portfolio</button>
+            </div>
+
+            <div class="form-group">
+                <label for="input-target-value">Target Value</label>
+                <div class="input-with-suffix">
+                    <input type="number" id="input-target-value" min="10" step="1">
+                    <span class="suffix">EUR</span>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="input-yearly-return">Assumed Yearly Return</label>
+                <div class="input-with-suffix">
+                    <input type="text" id="input-yearly-return" inputmode="decimal">
+                    <span class="suffix">%</span>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="input-monthly-contribution">Monthly Contribution</label>
+                <div class="input-with-suffix">
+                    <input type="number" id="input-monthly-contribution" min="0" step="1">
+                    <span class="suffix">EUR</span>
+                </div>
+            </div>
+
+            <button type="submit" class="btn-save">Save</button>
+        </form>
     </div>
 </body>
 


### PR DESCRIPTION
## Summary

Adds a configuration form that appears when the page is opened without query parameters, replacing the blank progress bar.

### Features

- **Portfolio IDs**: Dynamic input fields — first field is always present, additional fields can be added via "+ Add portfolio" button and removed individually. Values are combined into the comma-separated `portfolioId` parameter.
- **Target Value**: Number input in EUR.
- **Assumed Yearly Return**: Text input with `inputmode="decimal"`. User-entered commas are converted to decimal points on save (e.g. `6,5` becomes `6.5`).
- **Monthly Contribution**: Number input in EUR.
- **Save**: Writes all parameters to the URL query string, triggering a page reload with the progress bar.
- **Edit shortcut**: Pressing `C` while viewing the progress bar reopens the form, pre-populated with current URL parameters. No visual cue is shown for this shortcut.
- Form is styled to match the existing dark theme.

### Files changed

| File | Change |
|---|---|
| `js/config-form.js` | New module — form show/hide, dynamic portfolio fields, URL parameter serialization |
| `js/main.js` | Show form when no query params present, bind `C` key to reopen form |
| `progress.html` | Form markup and CSS styles |